### PR TITLE
Add synchronized blocks

### DIFF
--- a/repo/build.gradle
+++ b/repo/build.gradle
@@ -112,7 +112,6 @@ bintray {
 dependencies {
   implementation "io.reactivex.rxjava2:rxjava:$rxjava"
   implementation "androidx.annotation:annotation:$androidx"
-  implementation "androidx.core:core:$androidx"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
   testImplementation "junit:junit:$junit"

--- a/repo/src/main/java/com/popinnow/android/repo/impl/MemoryCacheImpl.kt
+++ b/repo/src/main/java/com/popinnow/android/repo/impl/MemoryCacheImpl.kt
@@ -31,6 +31,7 @@ internal class MemoryCacheImpl<T : Any> constructor(
   private val logger by lazy { Logger("MemoryCache[$debug]", debug.isNotBlank()) }
 
   // Data backing field
+  private val lock = Any()
   @Volatile private var data: Entry<T>? = null
 
   init {
@@ -39,34 +40,38 @@ internal class MemoryCacheImpl<T : Any> constructor(
 
   @CheckResult
   private fun hasCachedData(): Boolean {
-    val cached = data
-    if (cached == null) {
-      logger.log { "Cached data is null, do not return" }
-      return false
-    }
+    synchronized(lock) {
+      val cached = data
+      if (cached == null) {
+        logger.log { "Cached data is null, do not return" }
+        return false
+      }
 
-    if (cached.data.isEmpty()) {
-      logger.log { "Cached data is empty, do not return" }
-      return false
-    }
+      if (cached.data.isEmpty()) {
+        logger.log { "Cached data is empty, do not return" }
+        return false
+      }
 
-    // If this is still true, then cached was not null, we unwrap with !!
-    val cachedTime = cached.time
-    val currentTime = System.nanoTime()
-    if (cachedTime + ttl < currentTime) {
-      logger.log { "Cached time is out of bounds. ${cachedTime + ttl} $currentTime" }
-      return false
-    } else {
-      return true
+      // If this is still true, then cached was not null, we unwrap with !!
+      val cachedTime = cached.time
+      val currentTime = System.nanoTime()
+      if (cachedTime + ttl < currentTime) {
+        logger.log { "Cached time is out of bounds. ${cachedTime + ttl} $currentTime" }
+        return false
+      } else {
+        return true
+      }
     }
   }
 
   override fun get(): Observable<T> {
     return Observable.defer {
       if (hasCachedData()) {
-        val list = ArrayList(requireNotNull(data).data)
-        logger.log { "Memory cache return data: ${ArrayList(list)}" }
-        return@defer Observable.fromIterable(list)
+        synchronized(lock) {
+          val list = ArrayList(requireNotNull(data).data)
+          logger.log { "Memory cache return data: ${ArrayList(list)}" }
+          return@defer Observable.fromIterable(list)
+        }
       } else {
         logger.log { "Memory cache is empty" }
         clearAll()
@@ -84,24 +89,28 @@ internal class MemoryCacheImpl<T : Any> constructor(
   }
 
   private inline fun addToCache(addToList: (ArrayList<T>) -> Unit) {
-    val list: ArrayList<T>
-    val cached = data
-    if (cached == null) {
-      list = ArrayList(1)
-    } else {
-      list = cached.data
-    }
-    addToList(list)
+    synchronized(lock) {
+      val list: ArrayList<T>
+      val cached = data
+      if (cached == null) {
+        list = ArrayList(1)
+      } else {
+        list = cached.data
+      }
+      addToList(list)
 
-    // Don't log list or its a ConcurrentModificationError. Wrap in a copy
-    val currentTime = System.nanoTime()
-    logger.log { "Put in memory cache: ($currentTime) ${ArrayList(list)}" }
-    data = Entry(currentTime, list)
+      // Don't log list or its a ConcurrentModificationError. Wrap in a copy
+      val currentTime = System.nanoTime()
+      logger.log { "Put in memory cache: ($currentTime) ${ArrayList(list)}" }
+      data = Entry(currentTime, list)
+    }
   }
 
   override fun clearAll() {
     logger.log { "Cleared" }
-    data = null
+    synchronized(lock) {
+      data = null
+    }
   }
 
   private data class Entry<T : Any> internal constructor(

--- a/repo/src/main/java/com/popinnow/android/repo/impl/MultiRepoImpl.kt
+++ b/repo/src/main/java/com/popinnow/android/repo/impl/MultiRepoImpl.kt
@@ -21,12 +21,13 @@ import com.popinnow.android.repo.MultiRepo
 import com.popinnow.android.repo.Repo
 import io.reactivex.Observable
 import io.reactivex.Single
+import java.util.concurrent.ConcurrentHashMap
 
 internal class MultiRepoImpl<T : Any> internal constructor(
   private val repoGenerator: (String) -> Repo<T>
 ) : MultiRepo<T> {
 
-  private val repoMap: MutableMap<String, Repo<T>> by lazy { LinkedHashMap<String, Repo<T>>() }
+  private val repoMap: MutableMap<String, Repo<T>> by lazy { ConcurrentHashMap<String, Repo<T>>() }
 
   @CheckResult
   private fun repoForKey(key: String): Repo<T> {


### PR DESCRIPTION
While the MemoryCache data field is marked volatile so that assignments on the field itself are safe, manipulation of the list field on the data object were not.

Synchronize access to the `data.data` field so that manipulation on the data list is safe.
Back the MultiRepo with a ConcurrentHashMap instead of a simple LinkedHashMap