### PR TITLE
Change the persisters so that they also accept Type arguments

### DIFF
--- a/repo-persister-gson/src/main/java/com/popinnow/android/repo/gson/GsonPersister.kt
+++ b/repo-persister-gson/src/main/java/com/popinnow/android/repo/gson/GsonPersister.kt
@@ -23,22 +23,35 @@ import com.popinnow.android.repo.Persister.PersisterMapper
 import com.popinnow.android.repo.RepoBuilder
 import java.io.File
 import java.lang.reflect.Type
+import java.util.concurrent.TimeUnit
 
+@CheckResult
 fun <T : Any> RepoBuilder<T>.persister(
+  file: File,
   gson: Gson,
-  type: Class<T>,
-  file: File
+  type: Class<T>
 ): RepoBuilder<T> {
   return this.persister(file, GsonPersister.create(gson, type))
 }
 
+@CheckResult
+fun <T : Any> RepoBuilder<T>.persister(
+  time: Long,
+  timeUnit: TimeUnit,
+  file: File,
+  gson: Gson,
+  type: Class<T>
+): RepoBuilder<T> {
+  return this.persister(time, timeUnit, file, GsonPersister.create(gson, type))
+}
+
 class GsonPersister<T : Any> internal constructor(
   private val gson: Gson,
-  private val type: Class<T>
+  private val type: Type
 ) : PersisterMapper<T> {
 
   @CheckResult
-  private fun typedList(type: Class<T>): Type {
+  private fun typedList(type: Type): Type {
     val token = TypeToken.get(type)
         .type
     return TypeToken.getParameterized(ArrayList::class.java, token)
@@ -60,6 +73,15 @@ class GsonPersister<T : Any> internal constructor(
     fun <T : Any> create(
       gson: Gson,
       type: Class<T>
+    ): PersisterMapper<T> {
+      return GsonPersister(gson, type)
+    }
+
+    @JvmStatic
+    @CheckResult
+    fun <T : Any> create(
+      gson: Gson,
+      type: Type
     ): PersisterMapper<T> {
       return GsonPersister(gson, type)
     }

--- a/repo-persister-moshi/src/main/java/com/popinnow/android/repo/moshi/MoshiPersister.kt
+++ b/repo-persister-moshi/src/main/java/com/popinnow/android/repo/moshi/MoshiPersister.kt
@@ -23,18 +23,32 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import java.io.File
+import java.lang.reflect.Type
+import java.util.concurrent.TimeUnit
 
+@CheckResult
 fun <T : Any> RepoBuilder<T>.persister(
+  file: File,
   moshi: Moshi,
-  type: Class<T>,
-  file: File
+  type: Class<T>
 ): RepoBuilder<T> {
   return this.persister(file, MoshiPersister.create(moshi, type))
 }
 
-class MoshiPersister<T : Any> internal constructor(
+@CheckResult
+fun <T : Any> RepoBuilder<T>.persister(
+  time: Long,
+  timeUnit: TimeUnit,
+  file: File,
   moshi: Moshi,
   type: Class<T>
+): RepoBuilder<T> {
+  return this.persister(time, timeUnit, file, MoshiPersister.create(moshi, type))
+}
+
+class MoshiPersister<T : Any> internal constructor(
+  moshi: Moshi,
+  type: Type
 ) : PersisterMapper<T> {
 
   private val adapter: JsonAdapter<List<T>>
@@ -60,6 +74,15 @@ class MoshiPersister<T : Any> internal constructor(
     fun <T : Any> create(
       moshi: Moshi,
       type: Class<T>
+    ): PersisterMapper<T> {
+      return MoshiPersister(moshi, type)
+    }
+
+    @JvmStatic
+    @CheckResult
+    fun <T : Any> create(
+      moshi: Moshi,
+      type: Type
     ): PersisterMapper<T> {
       return MoshiPersister(moshi, type)
     }

--- a/repo/src/main/java/com/popinnow/android/repo/impl/Logger.kt
+++ b/repo/src/main/java/com/popinnow/android/repo/impl/Logger.kt
@@ -32,7 +32,8 @@ internal class Logger internal constructor(
     lazyMessage: () -> String
   ) {
     if (debug) {
-      System.err.println("$tag: ${lazyMessage()} $throwable")
+      System.err.println("$tag: ${lazyMessage()}")
+      System.err.println("$tag: $throwable")
     }
   }
 }

--- a/repo/src/main/java/com/popinnow/android/repo/impl/PersisterImpl.kt
+++ b/repo/src/main/java/com/popinnow/android/repo/impl/PersisterImpl.kt
@@ -187,17 +187,17 @@ internal class PersisterImpl<T : Any> internal constructor(
   @CheckResult
   private fun writeFile(data: ArrayList<T>): Boolean {
     synchronized(lock) {
-      if (!file.isFile || file.isDirectory) {
-        logger.log { "File provided is a directory" }
-        return false
-      }
-
       if (!file.exists()) {
         if (file.createNewFile()) {
           logger.log { "Created new file: $file" }
         } else {
           logger.log { "Failed to create new file: $file" }
         }
+      }
+
+      if (!file.isFile || file.isDirectory) {
+        logger.log { "File provided is a directory" }
+        return false
       }
 
       file.sink()

--- a/repo/src/main/java/com/popinnow/android/repo/impl/PersisterImpl.kt
+++ b/repo/src/main/java/com/popinnow/android/repo/impl/PersisterImpl.kt
@@ -171,7 +171,7 @@ internal class PersisterImpl<T : Any> internal constructor(
     append: Boolean
   ) {
     val existingData: ArrayList<T>
-    if (append) {
+    if (append && isFileValid()) {
       existingData = readFromFile()
     } else {
       existingData = arrayListOf()

--- a/repo/src/main/java/com/popinnow/android/repo/impl/PersisterImpl.kt
+++ b/repo/src/main/java/com/popinnow/android/repo/impl/PersisterImpl.kt
@@ -160,7 +160,7 @@ internal class PersisterImpl<T : Any> internal constructor(
           }
 
           override fun onError(e: Throwable) {
-            logger.log { "Failed to write '$values' to $file" }
+            logger.error(e) { "Failed to write '$values' to $file" }
             onWriteComplete(false)
           }
         })

--- a/repo/src/main/java/com/popinnow/android/repo/impl/PersisterImpl.kt
+++ b/repo/src/main/java/com/popinnow/android/repo/impl/PersisterImpl.kt
@@ -207,6 +207,7 @@ internal class PersisterImpl<T : Any> internal constructor(
               val json = mapper.serializeToString(data)
               logger.log { "Map data to json: $json" }
               it.writeUtf8(json)
+              it.flush()
 
               // Update last modified time which is used as the TTL
               // Files can only go to millisecond accuracy
@@ -217,6 +218,7 @@ internal class PersisterImpl<T : Any> internal constructor(
               return false
             }
           }
+
     }
   }
 


### PR DESCRIPTION
Type arguments allow one to specify a complex class as the Repo type
such as a List<String>. This could not be accurately expressed in
something like a List.class